### PR TITLE
add custom shim for kubebuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ os:
   - linux
   - osx
 
+# only build master branch and PR's
+branches:
+  only:
+    - master
+
 before_script:
   - git clone --branch master --depth=1 https://github.com/asdf-vm/asdf.git asdf
   - source asdf/asdf.sh

--- a/shims/kubebuilder
+++ b/shims/kubebuilder
@@ -1,0 +1,4 @@
+#!/bin/bash
+kbpath=$(asdf where kubebuilder)
+export KUBEBUILDER_ASSETS="${kbpath}/bin"
+"${kbpath}/bin/kubebuilder" "$@"


### PR DESCRIPTION
Allows setting of `KUBEBUILDER_ASSETS` environment variable so kubebuilder can find the binary assets as per [kubernetes-sigs/kubebuilder/issues/326](https://github.com/kubernetes-sigs/kubebuilder/issues/326#issuecomment-431365391).
